### PR TITLE
max-width not needed for main container

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -8,9 +8,6 @@ header {
 th.sortable.headerSortUp::after { content: " \f0dd"; font-family: FontAwesome;}
 th.sortable.headerSortDown::after { content: " \f0de"; font-family: FontAwesome;}
 th.sortable::after { content: " \f0dc"; font-family: FontAwesome;}
-.container.main {
-  max-width: 1200px;
-}
 h3 {
   text-align: center;
 }


### PR DESCRIPTION
Bootstrap already provides a sensible container width, hence max-width is useless in this case.
